### PR TITLE
Make auto_dereference optional

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,9 +2,14 @@
 Changelog
 =========
 
+Changes in 0.9.0-sm1
+====================
+- Added option to disable auto-dereferencing on specific fields to improve
+  performance when accessing large data structures without embedded documents
+  or dbrefs.
 
-Changes in 0.9.X - DEV
-======================
+Changes in 0.9.0
+================
 - Update FileField when creating a new file #714
 - Added `EmbeddedDocumentListField` for Lists of Embedded Documents. #826
 - ComplexDateTimeField should fall back to None when null=True #864

--- a/mongoengine/__init__.py
+++ b/mongoengine/__init__.py
@@ -15,7 +15,7 @@ import django
 __all__ = (list(document.__all__) + fields.__all__ + connection.__all__ +
            list(queryset.__all__) + signals.__all__ + list(errors.__all__))
 
-VERSION = (0, 9, 0)
+VERSION = (0, 9, 0, '-sm1')
 
 
 def get_version():

--- a/mongoengine/base/document.py
+++ b/mongoengine/base/document.py
@@ -677,7 +677,7 @@ class BaseDocument(object):
             fields = copy.copy(fields)
 
         for field_name, field in fields.iteritems():
-            field._auto_dereference = _auto_dereference
+            field._auto_dereference &= _auto_dereference
             if field.db_field in data:
                 value = data[field.db_field]
                 try:

--- a/mongoengine/base/fields.py
+++ b/mongoengine/base/fields.py
@@ -203,6 +203,10 @@ class ComplexBaseField(BaseField):
 
     field = None
 
+    def __init__(self, auto_dereference=True, *args, **kwargs):
+        super(ComplexBaseField, self).__init__(*args, **kwargs)
+        self._auto_dereference = auto_dereference
+
     def __get__(self, instance, owner):
         """Descriptor to automatically dereference references.
         """


### PR DESCRIPTION
Automatic dereferencing is needed for complex objects that may contain embedded documents (or dbrefs), but is a huge performance hit for large and frequently-accessed data structures. Make it possible to disable it for specific fields.
