### PR TITLE
Skip even more auto-dereferencing operations on save / load

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,7 +2,12 @@
 Changelog
 =========
 
-Changes in 0.9.0-sm1
+Changes in 0.9.0+sm2
+====================
+- Extended auto_dereference=False to skip more redundant operations while saving
+  and loading huge data structures.
+
+Changes in 0.9.0+sm1
 ====================
 - Added option to disable auto-dereferencing on specific fields to improve
   performance when accessing large data structures without embedded documents

--- a/mongoengine/__init__.py
+++ b/mongoengine/__init__.py
@@ -15,7 +15,7 @@ import django
 __all__ = (list(document.__all__) + fields.__all__ + connection.__all__ +
            list(queryset.__all__) + signals.__all__ + list(errors.__all__))
 
-VERSION = (0, 9, 0, '+sm1')
+VERSION = (0, 9, 0, '+sm2')
 
 
 def get_version():

--- a/mongoengine/base/fields.py
+++ b/mongoengine/base/fields.py
@@ -258,13 +258,15 @@ class ComplexBaseField(BaseField):
     def to_python(self, value):
         """Convert a MongoDB-compatible type to a Python type.
         """
-        Document = _import_class('Document')
 
         if isinstance(value, basestring):
             return value
-
         if hasattr(value, 'to_python'):
             return value.to_python()
+        if not self._auto_dereference:
+            return value
+
+        Document = _import_class('Document')
 
         is_list = False
         if not hasattr(value, 'items'):
@@ -300,12 +302,15 @@ class ComplexBaseField(BaseField):
     def to_mongo(self, value):
         """Convert a Python type to a MongoDB-compatible type.
         """
-        Document = _import_class("Document")
-        EmbeddedDocument = _import_class("EmbeddedDocument")
-        GenericReferenceField = _import_class("GenericReferenceField")
 
         if isinstance(value, basestring):
             return value
+        if not self._auto_dereference:
+            return value
+
+        Document = _import_class("Document")
+        EmbeddedDocument = _import_class("EmbeddedDocument")
+        GenericReferenceField = _import_class("GenericReferenceField")
 
         if hasattr(value, 'to_mongo'):
             if isinstance(value, Document):


### PR DESCRIPTION
If auto-dereference is set to false on a field, there's no reason to crawl it while saving or loading it either. Cuts >50% off the time to save and load documents containing large lists and dictionaries.
