### PR TITLE
MA-3065: port mongoengine to pymongo 3.x

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,12 @@
 Changelog
 =========
 
+Changes in 0.9.0+sm3
+====================
+- Port mongoengine to work with pymongo 3.x. This change is mostly backwards
+  compatible with 0.9.0, except that read and write concern can no longer be
+  controlled on a per-operation basis.
+
 Changes in 0.9.0+sm2
 ====================
 - Extended auto_dereference=False to skip more redundant operations while saving

--- a/mongoengine/base/document.py
+++ b/mongoengine/base/document.py
@@ -565,31 +565,6 @@ class BaseDocument(object):
                     changed_fields, key, data, inspected)
         return changed_fields
 
-    @staticmethod
-    def _prune_changed_fields(changed_fields):
-        """Remove redundant fields from the list of changed fields.
-
-        >>> sorted(BaseDocument._prune_changed_fields(['a', 'b', 'b.c', 'c.d']))
-        ['a', 'b', 'c.d']
-
-        """
-        parents = set()
-        for key in sorted(changed_fields, key=len):
-            key_prefix = ''
-            has_parent = False
-            for key_part in key.split('.'):
-                if not key_prefix:
-                    key_prefix = key_part
-                else:
-                    key_prefix = '%s.%s' % (key_prefix, key_part)
-                if key_prefix in parents:
-                    has_parent = True
-                    break
-            if not has_parent:
-                parents.add(key)
-
-        return list(parents)
-
     def _delta(self):
         """Returns the delta (set, unset) of the changes for a document.
         Gets any values that have been explicitly changed.
@@ -597,8 +572,7 @@ class BaseDocument(object):
         # Handles cases where not loaded from_son but has _id
         doc = self.to_mongo()
 
-        changed_fields = self._get_changed_fields()
-        set_fields = self._prune_changed_fields(changed_fields)
+        set_fields = self._get_changed_fields()
         unset_data = {}
         parts = []
         if hasattr(self, '_changed_fields'):

--- a/mongoengine/base/document.py
+++ b/mongoengine/base/document.py
@@ -565,6 +565,31 @@ class BaseDocument(object):
                     changed_fields, key, data, inspected)
         return changed_fields
 
+    @staticmethod
+    def _prune_changed_fields(changed_fields):
+        """Remove redundant fields from the list of changed fields.
+
+        >>> sorted(BaseDocument._prune_changed_fields(['a', 'b', 'b.c', 'c.d']))
+        ['a', 'b', 'c.d']
+
+        """
+        parents = set()
+        for key in sorted(changed_fields, key=len):
+            key_prefix = ''
+            has_parent = False
+            for key_part in key.split('.'):
+                if not key_prefix:
+                    key_prefix = key_part
+                else:
+                    key_prefix = '%s.%s' % (key_prefix, key_part)
+                if key_prefix in parents:
+                    has_parent = True
+                    break
+            if not has_parent:
+                parents.add(key)
+
+        return list(parents)
+
     def _delta(self):
         """Returns the delta (set, unset) of the changes for a document.
         Gets any values that have been explicitly changed.
@@ -572,7 +597,8 @@ class BaseDocument(object):
         # Handles cases where not loaded from_son but has _id
         doc = self.to_mongo()
 
-        set_fields = self._get_changed_fields()
+        changed_fields = self._get_changed_fields()
+        set_fields = self._prune_changed_fields(changed_fields)
         unset_data = {}
         parts = []
         if hasattr(self, '_changed_fields'):

--- a/mongoengine/base/metaclasses.py
+++ b/mongoengine/base/metaclasses.py
@@ -271,7 +271,6 @@ class TopLevelDocumentMetaclass(DocumentMetaclass):
                 'indexes': [],  # indexes to be ensured at runtime
                 'id_field': None,
                 'index_background': False,
-                'index_drop_dups': False,
                 'index_opts': None,
                 'delete_rules': None,
                 'allow_inheritance': None,

--- a/mongoengine/connection.py
+++ b/mongoengine/connection.py
@@ -19,7 +19,7 @@ _dbs = {}
 
 
 def register_connection(alias, name=None, host=None, port=None,
-                        read_preference=False,
+                        read_preference=pymongo.ReadPreference.PRIMARY,
                         username=None, password=None, authentication_source=None,
                         **kwargs):
     """Add a connection.
@@ -74,7 +74,7 @@ def disconnect(alias=DEFAULT_CONNECTION_NAME):
     global _dbs
 
     if alias in _connections:
-        get_connection(alias=alias).disconnect()
+        get_connection(alias=alias).close()
         del _connections[alias]
     if alias in _dbs:
         del _dbs[alias]

--- a/mongoengine/document.py
+++ b/mongoengine/document.py
@@ -291,8 +291,10 @@ class Document(BaseDocument):
             if '_id' not in doc:
                 object_id = collection.insert_one(doc).inserted_id
             elif created:
-                # If created is true then the delta will not be in sync with the
-                # document; we must upsert the document to preserve all fields.
+                # If `created` is true then _delta() will be out of sync. Any fields
+                # set via the constructor will be missing from the delta and will not
+                # be stored in mongo. We perform an upsert to work around the broken
+                # change tracking logic.
                 object_id = doc['_id']
                 collection.replace_one({"_id": object_id}, doc, upsert=True)
             else:

--- a/mongoengine/document.py
+++ b/mongoengine/document.py
@@ -4,7 +4,6 @@ import hashlib
 import pymongo
 import re
 
-from pymongo.read_preferences import ReadPreference
 from bson import ObjectId
 from bson.dbref import DBRef
 from mongoengine import signals
@@ -237,7 +236,7 @@ class Document(BaseDocument):
         return True
 
     def save(self, force_insert=False, validate=True, clean=True,
-             write_concern=None,  cascade=None, cascade_kwargs=None,
+              cascade=None, cascade_kwargs=None,
              _refs=None, save_condition=None, **kwargs):
         """Save the :class:`~mongoengine.Document` to the database. If the
         document already exists, it will be updated, otherwise it will be
@@ -248,14 +247,6 @@ class Document(BaseDocument):
         :param validate: validates the document; set to ``False`` to skip.
         :param clean: call the document clean method, requires `validate` to be
             True.
-        :param write_concern: Extra keyword arguments are passed down to
-            :meth:`~pymongo.collection.Collection.save` OR
-            :meth:`~pymongo.collection.Collection.insert`
-            which will be used as options for the resultant
-            ``getLastError`` command.  For example,
-            ``save(..., write_concern={w: 2, fsync: True}, ...)`` will
-            wait until at least two servers have recorded the write and
-            will force an fsync on the primary server.
         :param cascade: Sets the flag for cascading saves.  You can set a
             default by setting "cascade" in the document __meta__
         :param cascade_kwargs: (optional) kwargs dictionary to be passed throw
@@ -286,9 +277,6 @@ class Document(BaseDocument):
         if validate:
             self.validate(clean=clean)
 
-        if write_concern is None:
-            write_concern = {"w": 1}
-
         doc = self.to_mongo()
 
         created = ('_id' not in doc or self._created or force_insert)
@@ -300,11 +288,13 @@ class Document(BaseDocument):
             collection = self._get_collection()
             if self._meta.get('auto_create_index', True):
                 self.ensure_indexes()
-            if created:
-                if force_insert:
-                    object_id = collection.insert(doc, **write_concern)
-                else:
-                    object_id = collection.save(doc, **write_concern)
+            if '_id' not in doc:
+                object_id = collection.insert_one(doc).inserted_id
+            elif created:
+                # If created is true then the delta will not be in sync with the
+                # document; we must upsert the document to preserve all fields.
+                object_id = doc['_id']
+                collection.replace_one({"_id": object_id}, doc, upsert=True)
             else:
                 object_id = doc['_id']
                 updates, removals = self._delta()
@@ -320,13 +310,6 @@ class Document(BaseDocument):
                     actual_key = self._db_field_map.get(k, k)
                     select_dict[actual_key] = doc[actual_key]
 
-                def is_new_object(last_error):
-                    if last_error is not None:
-                        updated = last_error.get("updatedExisting")
-                        if updated is not None:
-                            return not updated
-                    return created
-
                 update_query = {}
 
                 if updates:
@@ -335,9 +318,9 @@ class Document(BaseDocument):
                     update_query["$unset"] = removals
                 if updates or removals:
                     upsert = save_condition is None
-                    last_error = collection.update(select_dict, update_query,
-                                                   upsert=upsert, **write_concern)
-                    created = is_new_object(last_error)
+                    result = collection.update_one(select_dict, update_query,
+                                                   upsert=upsert)
+                    created = result.upserted_id is not None
 
             if cascade is None:
                 cascade = self._meta.get(
@@ -347,7 +330,6 @@ class Document(BaseDocument):
                 kwargs = {
                     "force_insert": force_insert,
                     "validate": validate,
-                    "write_concern": write_concern,
                     "cascade": cascade
                 }
                 if cascade_kwargs:  # Allow granular control over cascades
@@ -440,22 +422,15 @@ class Document(BaseDocument):
         # Need to add shard key to query, or you get an error
         return self._qs.filter(**self._object_key).update_one(**kwargs)
 
-    def delete(self, **write_concern):
+    def delete(self):
         """Delete the :class:`~mongoengine.Document` from the database. This
         will only take effect if the document has been previously saved.
 
-        :param write_concern: Extra keyword arguments are passed down which
-            will be used as options for the resultant
-            ``getLastError`` command.  For example,
-            ``save(..., write_concern={w: 2, fsync: True}, ...)`` will
-            wait until at least two servers have recorded the write and
-            will force an fsync on the primary server.
         """
         signals.pre_delete.send(self.__class__, document=self)
 
         try:
-            self._qs.filter(
-                **self._object_key).delete(write_concern=write_concern, _from_doc_delete=True)
+            self._qs.filter(**self._object_key).delete(_from_doc_delete=True)
         except pymongo.errors.OperationFailure, err:
             message = u'Could not delete document (%s)' % err.message
             raise OperationError(message)
@@ -543,9 +518,8 @@ class Document(BaseDocument):
 
         if not self.pk:
             raise self.DoesNotExist("Document does not exist")
-        obj = self._qs.read_preference(ReadPreference.PRIMARY).filter(
-            **self._object_key).only(*fields).limit(1
-                                                    ).select_related(max_depth=max_depth)
+        obj = self._qs.filter(**self._object_key).only(*fields).limit(1
+                  ).select_related(max_depth=max_depth)
 
         if obj:
             obj = obj[0]
@@ -620,8 +594,7 @@ class Document(BaseDocument):
         db.drop_collection(cls._get_collection_name())
 
     @classmethod
-    def ensure_index(cls, key_or_list, drop_dups=False, background=False,
-                     **kwargs):
+    def ensure_index(cls, key_or_list, background=False, **kwargs):
         """Ensure that the given indexes are in place.
 
         :param key_or_list: a single index key or a list of index keys (to
@@ -631,11 +604,10 @@ class Document(BaseDocument):
         index_spec = cls._build_index_spec(key_or_list)
         index_spec = index_spec.copy()
         fields = index_spec.pop('fields')
-        index_spec['drop_dups'] = drop_dups
         index_spec['background'] = background
         index_spec.update(kwargs)
 
-        return cls._get_collection().ensure_index(fields, **index_spec)
+        return cls._get_collection().create_index(fields, **index_spec)
 
     @classmethod
     def ensure_indexes(cls):
@@ -647,7 +619,6 @@ class Document(BaseDocument):
                   `auto_create_index` to False in the documents meta data
         """
         background = cls._meta.get('index_background', False)
-        drop_dups = cls._meta.get('index_drop_dups', False)
         index_opts = cls._meta.get('index_opts') or {}
         index_cls = cls._meta.get('index_cls', True)
 
@@ -672,14 +643,13 @@ class Document(BaseDocument):
                 cls_indexed = cls_indexed or includes_cls(fields)
                 opts = index_opts.copy()
                 opts.update(spec)
-                collection.ensure_index(fields, background=background,
-                                        drop_dups=drop_dups, **opts)
+                collection.create_index(fields, background=background, **opts)
 
         # If _cls is being used (for polymorphism), it needs an index,
         # only if another index doesn't begin with _cls
         if (index_cls and not cls_indexed and
                 cls._meta.get('allow_inheritance', ALLOW_INHERITANCE) is True):
-            collection.ensure_index('_cls', background=background,
+            collection.create_index('_cls', background=background,
                                     **index_opts)
 
     @classmethod

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-pymongo>=2.7.1
+pymongo>=3.4.0
 nose

--- a/setup.py
+++ b/setup.py
@@ -77,7 +77,7 @@ setup(name='mongoengine',
       long_description=LONG_DESCRIPTION,
       platforms=['any'],
       classifiers=CLASSIFIERS,
-      install_requires=['pymongo>=2.7.1'],
+      install_requires=['pymongo>=3.4.0'],
       test_suite='nose.collector',
       **extra_opts
 )

--- a/tests/fields/fields.py
+++ b/tests/fields/fields.py
@@ -3066,7 +3066,7 @@ class FieldTest(unittest.TestCase):
             field_1 = StringField(db_field='f')
 
         class Doc(Document):
-            my_id = IntField(required=True, unique=True, primary_key=True)
+            my_id = IntField(required=True, primary_key=True)
             embed_me = DynamicField(db_field='e')
             field_x = StringField(db_field='x')
 
@@ -3089,7 +3089,7 @@ class FieldTest(unittest.TestCase):
             field_1 = StringField(db_field='f')
 
         class Doc(Document):
-            my_id = IntField(required=True, unique=True, primary_key=True)
+            my_id = IntField(required=True, primary_key=True)
             embed_me = DynamicField(db_field='e')
             field_x = StringField(db_field='x')
 

--- a/tests/fields/geo.py
+++ b/tests/fields/geo.py
@@ -6,6 +6,7 @@ import unittest
 
 from mongoengine import *
 from mongoengine.connection import get_db
+from pymongo.errors import OperationFailure
 
 __all__ = ("GeoFieldTest", )
 
@@ -338,10 +339,11 @@ class GeoFieldTest(unittest.TestCase):
 
         list(Parent.objects)
 
-        collection = Parent._get_collection()
-        info = collection.index_information()
-
-        self.assertFalse('location_2d' in info)
+        with self.assertRaises(OperationFailure):
+            collection = Parent._get_collection()
+            # In pymongo 3.x _get_collection() will not create a collection
+            # that has no indexes defined, so index_information() fails.
+            collection.index_information()
 
         self.assertEqual(len(Parent._geo_indices()), 0)
         self.assertEqual(len(Location._geo_indices()), 1)

--- a/tests/queryset/modify.py
+++ b/tests/queryset/modify.py
@@ -94,7 +94,7 @@ class FindAndModifyTest(unittest.TestCase):
         Doc(id=1, value=1).save()
 
         old_doc = Doc.objects(id=1).only("id").modify(set__value=-1)
-        self.assertEqual(old_doc.to_mongo(), {"_id": 1})
+        self.assertEqual(dict(old_doc.to_mongo()), {"_id": 1})
         self.assertDbEqual([{"_id": 0, "value": 0}, {"_id": 1, "value": -1}])
 
 


### PR DESCRIPTION
The new version should be backwards-compatible with the old version, aside from a few minor changes:

* Read / write concern can no longer be controlled on a per-operation basis. Use `pymongo.collection.Collection.with_options` instead.
* Indexes with drop_dups are no longer supported.
* The `full_response` option has been removed from `QuerySet.modify(...)` since pymongo no longer supports it.