### PR TITLE
task/MA-4707

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,10 @@
 Changelog
 =========
 
+Changes in 0.9.0+sm5
+====================
+- Fix StopIteration issues for Python 3.7
+
 Changes in 0.9.0+sm4
 ====================
 - Remove the default Schema validation which looks for fields in the document that are not in

--- a/mongoengine/__init__.py
+++ b/mongoengine/__init__.py
@@ -15,7 +15,7 @@ import django
 __all__ = (list(document.__all__) + fields.__all__ + connection.__all__ +
            list(queryset.__all__) + signals.__all__ + list(errors.__all__))
 
-VERSION = (0, 9, 0, '+sm4')
+VERSION = (0, 9, 0, '+sm5')
 
 
 def get_version():

--- a/mongoengine/queryset/queryset.py
+++ b/mongoengine/queryset/queryset.py
@@ -76,7 +76,7 @@ class QuerySet(BaseQuerySet):
                 yield self._result_cache[pos]
                 pos = pos + 1
             if not self._has_more:
-                raise StopIteration
+                return
             if len(self._result_cache) <= pos:
                 self._populate_cache()
 


### PR DESCRIPTION
Support Py3.7 for mongoengine. (https://www.python.org/dev/peps/pep-0479/)

StopIteration is no longer manually used so one should just return instead. 

- [x] Tag after PR approved