### PR TITLE
MA-6335: Minor update for MongoDB 4.2

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,6 +1,10 @@
 =========
 Changelog
 =========
+Changes in 0.9.0+sm7
+====================
+- Only set no_cursor_timeout when requested ([#2160](https://github.com/MongoEngine/mongoengine/pull/2160))
+
 Changes in 0.9.0+sm6
 ====================
 Fix more Python 3 issues.

--- a/mongoengine/__init__.py
+++ b/mongoengine/__init__.py
@@ -15,7 +15,7 @@ import django
 __all__ = (list(document.__all__) + fields.__all__ + connection.__all__ +
            list(queryset.__all__) + signals.__all__ + list(errors.__all__))
 
-VERSION = (0, 9, 0, '+sm6')
+VERSION = (0, 9, 0, '+sm7')
 
 
 def get_version():

--- a/mongoengine/queryset/base.py
+++ b/mongoengine/queryset/base.py
@@ -1319,7 +1319,9 @@ class BaseQuerySet(object):
 
     @property
     def _cursor_args(self):
-        cursor_args = {'no_cursor_timeout': not self._timeout}
+        cursor_args = {}
+        if not self._timeout:
+            cursor_args["no_cursor_timeout"] = True
         modifiers = {}
         if self._max_time_ms is not None:
             modifiers['$maxTimeMS'] = self._max_time_ms


### PR DESCRIPTION
MA unit tests exposed this error when using MongoDB 4.2. Modified the parameter to only be set when it's specified like in the PR to the mongoengine repo: [#2160](https://github.com/MongoEngine/mongoengine/pull/2160). Updated Changelog and version to `0.9+sm7`.